### PR TITLE
feat: sync back-references

### DIFF
--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -6,9 +6,15 @@ import c from "kleur";
 import * as superjson from "superjson";
 import { createTson, tsonDate, tsonRegExp, tsonSet } from "tupleson";
 
-const time_formatter = new Intl.NumberFormat('en-US', { unit: 'millisecond', style: 'unit' });
-const size_formatter = new Intl.NumberFormat('en-US', { unit: 'byte', style: 'unit' });
-const number_formatter = new Intl.NumberFormat('en-US');
+const time_formatter = new Intl.NumberFormat("en-US", {
+	style: "unit",
+	unit: "millisecond",
+});
+const size_formatter = new Intl.NumberFormat("en-US", {
+	style: "unit",
+	unit: "byte",
+});
+const number_formatter = new Intl.NumberFormat("en-US");
 
 const obj = {
 	array: [{ foo: 1 }, { bar: 2 }, { baz: 3 }],
@@ -32,16 +38,24 @@ const devalue_stringified = devalue.stringify(obj);
 const arson_stringified = ARSON.stringify(obj);
 const tson_serialized = tson.stringify(obj);
 
-console.log('-- SERIALIZED SIZE --\n')
+console.log("-- SERIALIZED SIZE --\n");
 
 console.log(
-	`superjson output: ${c.bold().cyan(size_formatter.format(superjson_serialized.length))}`,
+	`superjson output: ${c
+		.bold()
+		.cyan(size_formatter.format(superjson_serialized.length))}`,
 );
 
-console.log(`tson output: ${c.bold().cyan(size_formatter.format(tson_serialized.length))}`);
+console.log(
+	`tson output: ${c
+		.bold()
+		.cyan(size_formatter.format(tson_serialized.length))}`,
+);
 // console.log(superjson_serialized);
 console.log(
-	`devalue.uneval output: ${c.bold().cyan(size_formatter.format(devalue_unevaled.length))}`,
+	`devalue.uneval output: ${c
+		.bold()
+		.cyan(size_formatter.format(devalue_unevaled.length))}`,
 );
 // console.log(devalue_unevaled);
 console.log(
@@ -50,7 +64,11 @@ console.log(
 		.cyan(size_formatter.format(devalue_stringified.length))}`,
 );
 // console.log(devalue_stringified);
-console.log(`arson output: ${c.bold().cyan(size_formatter.format(arson_stringified.length))}`);
+console.log(
+	`arson output: ${c
+		.bold()
+		.cyan(size_formatter.format(arson_stringified.length))}`,
+);
 // console.log(arson_stringified);
 
 // const superjson_deserialized = superjson.parse(superjson_serialized);
@@ -68,10 +86,13 @@ function test(fn, label = fn.toString()) {
 	while (i--) {
 		fn();
 	}
+
 	const delta = Date.now() - start;
 	const after_snap = process.memoryUsage();
 	console.log(
-		`${number_formatter.format(iterations)} iterations in ${c.bold().cyan(time_formatter.format(delta))}`,
+		`${number_formatter.format(iterations)} iterations in ${c
+			.bold()
+			.cyan(time_formatter.format(delta))}`,
 	);
 	// log memory usage delta
 	for (const key in after_snap) {
@@ -83,7 +104,7 @@ function test(fn, label = fn.toString()) {
 	}
 }
 
-console.log('\n-- SERIALIZATION DURATION --')
+console.log("\n-- SERIALIZATION DURATION --");
 
 // serialization
 test(() => superjson.stringify(obj));
@@ -92,7 +113,7 @@ test(() => devalue.uneval(obj));
 test(() => devalue.stringify(obj));
 test(() => ARSON.stringify(obj));
 
-console.log('\n-- DESERIALIZATION DURATION --')
+console.log("\n-- DESERIALIZATION DURATION --");
 
 // deserialization
 test(() => superjson.parse(superjson_serialized));

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -24,8 +24,6 @@ const obj = {
 	set: new Set([1, 2, 3]),
 	xss: '</script><script>alert("XSS")</script>',
 };
-
-// circular references are not supported by tupleson
 obj.self = obj;
 
 const tson = createTson({

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -1,10 +1,14 @@
 // taken from https://github.com/Rich-Harris/superjson-and-devalue
 
 import ARSON from "arson";
-import { parse, stringify, uneval } from "devalue";
+import * as devalue from "devalue";
 import c from "kleur";
 import * as superjson from "superjson";
 import { createTson, tsonDate, tsonRegExp, tsonSet } from "tupleson";
+
+const time_formatter = new Intl.NumberFormat('en-US', { unit: 'millisecond', style: 'unit' });
+const size_formatter = new Intl.NumberFormat('en-US', { unit: 'byte', style: 'unit' });
+const number_formatter = new Intl.NumberFormat('en-US');
 
 const obj = {
 	array: [{ foo: 1 }, { bar: 2 }, { baz: 3 }],
@@ -16,35 +20,37 @@ const obj = {
 };
 
 // circular references are not supported by tupleson
-// obj.self = obj;
+obj.self = obj;
 
 const tson = createTson({
 	types: [tsonDate, tsonRegExp, tsonSet],
 });
 
 const superjson_serialized = superjson.stringify(obj);
-const devalue_unevaled = uneval(obj);
-const devalue_stringified = stringify(obj);
+const devalue_unevaled = devalue.uneval(obj);
+const devalue_stringified = devalue.stringify(obj);
 const arson_stringified = ARSON.stringify(obj);
 const tson_serialized = tson.stringify(obj);
 
+console.log('-- SERIALIZED SIZE --\n')
+
 console.log(
-	`superjson output: ${c.bold().cyan(superjson_serialized.length)} bytes`,
+	`superjson output: ${c.bold().cyan(size_formatter.format(superjson_serialized.length))}`,
 );
 
-console.log(`tson output: ${c.bold().cyan(tson_serialized.length)} bytes`);
+console.log(`tson output: ${c.bold().cyan(size_formatter.format(tson_serialized.length))}`);
 // console.log(superjson_serialized);
 console.log(
-	`devalue.uneval output: ${c.bold().cyan(devalue_unevaled.length)} bytes`,
+	`devalue.uneval output: ${c.bold().cyan(size_formatter.format(devalue_unevaled.length))}`,
 );
 // console.log(devalue_unevaled);
 console.log(
 	`devalue.stringify output: ${c
 		.bold()
-		.cyan(devalue_stringified.length)} bytes`,
+		.cyan(size_formatter.format(devalue_stringified.length))}`,
 );
 // console.log(devalue_stringified);
-console.log(`arson output: ${c.bold().cyan(arson_stringified.length)} bytes`);
+console.log(`arson output: ${c.bold().cyan(size_formatter.format(arson_stringified.length))}`);
 // console.log(arson_stringified);
 
 // const superjson_deserialized = superjson.parse(superjson_serialized);
@@ -53,31 +59,46 @@ console.log(`arson output: ${c.bold().cyan(arson_stringified.length)} bytes`);
 const iterations = 1e6;
 
 function test(fn, label = fn.toString()) {
-	const start = Date.now();
 	console.log();
 	console.log(c.bold(label));
+	global.gc(); // force garbage collection before each test
 	let i = iterations;
+	const before_snap = process.memoryUsage();
+	const start = Date.now();
 	while (i--) {
 		fn();
 	}
-
+	const delta = Date.now() - start;
+	const after_snap = process.memoryUsage();
 	console.log(
-		`${iterations} iterations in ${c.bold().cyan(Date.now() - start)}ms`,
+		`${number_formatter.format(iterations)} iterations in ${c.bold().cyan(time_formatter.format(delta))}`,
 	);
+	// log memory usage delta
+	for (const key in after_snap) {
+		const before = before_snap[key];
+		const after = after_snap[key];
+		const diff = after - before;
+		const color = diff < 0 ? c.green : c.red;
+		console.log(`  ${key}: ${color(size_formatter.format(diff))}`);
+	}
 }
+
+console.log('\n-- SERIALIZATION DURATION --')
 
 // serialization
 test(() => superjson.stringify(obj));
 test(() => tson.stringify(obj));
-test(() => uneval(obj));
-test(() => stringify(obj));
+test(() => devalue.uneval(obj));
+test(() => devalue.stringify(obj));
 test(() => ARSON.stringify(obj));
+
+console.log('\n-- DESERIALIZATION DURATION --')
 
 // deserialization
 test(() => superjson.parse(superjson_serialized));
 test(() => tson.parse(tson_serialized));
 test(() => eval(`(${devalue_unevaled})`));
 test(() => ARSON.parse(arson_stringified));
-test(() => parse(devalue_stringified));
+test(() => devalue.parse(devalue_stringified));
 
 console.log();

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -7,7 +7,7 @@
 	"type": "module",
 	"scripts": {
 		"postinstall": "cd ../ && pnpm run build",
-		"start": "node index.js"
+		"start": "node --expose-gc --max-old-space-size=8192 index.js"
 	},
 	"dependencies": {
 		"arson": "^0.2.6",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -63,12 +63,12 @@ test("back-reference: circular object reference", () => {
 		"{
 		  \\"json\\": {
 		    \\"a\\": [
-		      \\"CIRCULAR\\",
+		      \\"Reference\\",
 		      \\"\\",
 		      \\"__tson\\"
 		    ],
 		    \\"b\\": [
-		      \\"CIRCULAR\\",
+		      \\"Reference\\",
 		      \\"\\",
 		      \\"__tson\\"
 		    ]
@@ -100,12 +100,12 @@ test("back-reference: circular array reference", () => {
 		"{
 		  \\"json\\": [
 		    [
-		      \\"CIRCULAR\\",
+		      \\"Reference\\",
 		      \\"\\",
 		      \\"__tson\\"
 		    ],
 		    [
-		      \\"CIRCULAR\\",
+		      \\"Reference\\",
 		      \\"\\",
 		      \\"__tson\\"
 		    ]
@@ -140,7 +140,7 @@ test("back-reference: referential equality", () => {
 		  \\"json\\": {
 		    \\"a\\": {},
 		    \\"b\\": [
-		      \\"CIRCULAR\\",
+		      \\"Reference\\",
 		      \\"a\\",
 		      \\"__tson\\"
 		    ],
@@ -150,7 +150,7 @@ test("back-reference: referential equality", () => {
 		      \\"__tson\\"
 		    ],
 		    \\"d\\": [
-		      \\"CIRCULAR\\",
+		      \\"Reference\\",
 		      \\"c\\",
 		      \\"__tson\\"
 		    ]
@@ -188,7 +188,7 @@ test("back-reference: grandparent reference", () => {
 		      \\"a\\": {
 		        \\"b\\": {
 		          \\"a\\": [
-		            \\"CIRCULAR\\",
+		            \\"Reference\\",
 		            \\"a__tson__a\\",
 		            \\"__tson__\\"
 		          ]
@@ -222,7 +222,7 @@ test("back-reference: self-referencing Map", () => {
 		      [
 		        \\"a\\",
 		        [
-		          \\"CIRCULAR\\",
+		          \\"Reference\\",
 		          \\"\\",
 		          \\"__tson__\\"
 		        ]
@@ -261,7 +261,7 @@ test("back-reference: self-referencing Map deep", () => {
 		        \\"a\\",
 		        {
 		          \\"foo\\": [
-		            \\"CIRCULAR\\",
+		            \\"Reference\\",
 		            \\"\\",
 		            \\"__tson__\\"
 		          ]
@@ -296,7 +296,7 @@ test("back-reference: self-referencing Set", () => {
 		    \\"Set\\",
 		    [
 		      [
-		        \\"CIRCULAR\\",
+		        \\"Reference\\",
 		        \\"\\",
 		        \\"__tson__\\"
 		      ]
@@ -330,7 +330,7 @@ test("back-reference: self-referencing Set deep", () => {
 		    [
 		      {
 		        \\"foo\\": [
-		          \\"CIRCULAR\\",
+		          \\"Reference\\",
 		          \\"\\",
 		          \\"__tson__\\"
 		        ]

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -200,6 +200,7 @@ test("back-reference: grandparent reference", () => {
 		}"
 	`);
 	expect(res).toEqual(expected);
+	expect(res["a"].a).toBe(res["a"].a.b.a);
 });
 
 test("back-reference: self-referencing Map", () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,7 +1,13 @@
 import { expect, test } from "vitest";
 
-import { TsonOptions, TsonType, createTson, createTsonAsync, tsonDate, tsonPromise } from "./index.js";
-import { expectError, waitError } from "./internals/testUtils.js";
+import {
+	TsonOptions,
+	TsonType,
+	createTson,
+	createTsonAsync,
+	tsonDate,
+} from "./index.js";
+import { waitError } from "./internals/testUtils.js";
 
 test("multiple handlers for primitive string found", () => {
 	const stringHandler: TsonType<string, never> = {
@@ -42,7 +48,7 @@ test("back-reference: circular object reference", () => {
 	expected["a"] = expected;
 	expected["b"] = expected;
 
-	const str = t.stringify(expected)
+	const str = t.stringify(expected);
 	const res = t.parse(str);
 
 	expect(res).toEqual(expected);
@@ -57,7 +63,7 @@ test("back-reference: circular array reference", () => {
 	expected[0] = expected;
 	expected[1] = expected;
 
-	const str = t.stringify(expected)
+	const str = t.stringify(expected);
 	const res = t.parse(str);
 
 	expect(res).toEqual(expected);
@@ -69,12 +75,12 @@ test("back-reference: non-circular complex reference", () => {
 	});
 
 	const expected: Record<string, unknown> = {};
-	expected["a"] = {}
-	expected["b"] = expected["a"]
-	expected["c"] = new Date()
-	expected["d"] = expected["c"]
+	expected["a"] = {};
+	expected["b"] = expected["a"];
+	expected["c"] = new Date();
+	expected["d"] = expected["c"];
 
-	const str = t.stringify(expected)
+	const str = t.stringify(expected);
 	const res = t.parse(str);
 
 	expect(res["b"]).toBe(res["a"]);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -52,6 +52,8 @@ test("back-reference: circular object reference", () => {
 	const res = t.parse(str);
 
 	expect(res).toEqual(expected);
+	expect(res).toBe(res["a"]);
+	expect(res["b"]).toBe(res["a"]);
 });
 
 test("back-reference: circular array reference", () => {
@@ -67,6 +69,8 @@ test("back-reference: circular array reference", () => {
 	const res = t.parse(str);
 
 	expect(res).toEqual(expected);
+	expect(res).toBe(res[0]);
+	expect(res[1]).toBe(res[0]);
 });
 
 test("back-reference: non-circular complex reference", () => {
@@ -83,6 +87,7 @@ test("back-reference: non-circular complex reference", () => {
 	const str = t.stringify(expected);
 	const res = t.parse(str);
 
+	expect(res).toEqual(expected);
 	expect(res["b"]).toBe(res["a"]);
 	expect(res["d"]).toBe(res["c"]);
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -115,7 +115,7 @@ test("back-reference: circular array reference", () => {
 	`);
 });
 
-test("back-reference: non-circular complex reference", () => {
+test("back-reference: referential equality", () => {
 	const t = createTson({
 		nonce: () => "__tson",
 		types: [tsonDate],

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -6,6 +6,7 @@ import {
 	createTson,
 	createTsonAsync,
 	tsonDate,
+	tsonMap,
 } from "./index.js";
 import { waitError } from "./internals/testUtils.js";
 
@@ -200,6 +201,40 @@ test("back-reference: grandparent reference", () => {
 	expect(res).toEqual(expected);
 });
 
+test("back-reference: self-referencing Map", () => {
+	const t = createTson({
+		nonce: () => "__tson__",
+		types: [tsonMap],
+	});
+
+	const expected = new Map();
+	expected.set("a", expected);
+
+	const str = t.stringify(expected, 2);
+
+	expect(str).toMatchInlineSnapshot(`
+		"{
+		  \\"json\\": [
+		    \\"Map\\",
+		    [
+		      [
+		        \\"a\\",
+		        [
+		          \\"CIRCULAR\\",
+		          \\"\\",
+		          \\"__tson__\\"
+		        ]
+		      ]
+		    ],
+		    \\"__tson__\\"
+		  ],
+		  \\"nonce\\": \\"__tson__\\"
+		}"
+	`);
+	const res = t.parse(str);
+
+	expect(res).toEqual(expected);
+});
 /**
  * WILL NOT WORK: the async serialize/deserialize functions haven't
  * been adapted to handle back-references yet

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -161,7 +161,7 @@ test("back-reference: non-circular complex reference", () => {
 
 test("back-reference: grandparent reference", () => {
 	const t = createTson({
-		nonce: () => "__tson",
+		nonce: () => "__tson__",
 		types: [tsonDate],
 	});
 
@@ -187,14 +187,14 @@ test("back-reference: grandparent reference", () => {
 		        \\"b\\": {
 		          \\"a\\": [
 		            \\"CIRCULAR\\",
-		            \\"a__tsona\\",
-		            \\"__tson\\"
+		            \\"a__tson__a\\",
+		            \\"__tson__\\"
 		          ]
 		        }
 		      }
 		    }
 		  },
-		  \\"nonce\\": \\"__tson\\"
+		  \\"nonce\\": \\"__tson__\\"
 		}"
 	`);
 	expect(res).toEqual(expected);

--- a/src/sync/deserialize.ts
+++ b/src/sync/deserialize.ts
@@ -9,7 +9,7 @@ import {
 	TsonTransformerSerializeDeserialize,
 } from "./syncTypes.js";
 
-type WalkFn = (value: unknown) => unknown;
+type WalkFn = (value: unknown, path?: (string|number)[]) => unknown;
 type WalkerFactory = (nonce: TsonNonce) => WalkFn;
 
 type AnyTsonTransformerSerializeDeserialize =
@@ -30,16 +30,51 @@ export function createTsonDeserialize(opts: TsonOptions): TsonDeserializeFn {
 	}
 
 	const walker: WalkerFactory = (nonce) => {
-		const walk: WalkFn = (value) => {
+		const seen = new Map<string, unknown>();
+		const backrefs: [circular_key: string, origin_key: string][] = [];
+		
+		const coreWalk: WalkFn = (value, path = []) => {
+			const key = path.join(nonce);
 			if (isTsonTuple(value, nonce)) {
 				const [type, serializedValue] = value;
+				if (type === 'CIRCULAR') {
+					backrefs.push([key, serializedValue as string]);
+					return;
+				}
 				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 				const transformer = typeByKey[type]!;
-				return transformer.deserialize(walk(serializedValue));
+				const parsed = transformer.deserialize(coreWalk(serializedValue, path));
+				seen.set(key, parsed);
+				return parsed;
 			}
 
-			return mapOrReturn(value, walk);
+			const parsed = mapOrReturn(value, (value, key) => coreWalk(value, [...path, key]));
+			if (parsed && typeof parsed === 'object') {
+				seen.set(key, parsed)
+			}
+			return parsed;
 		};
+
+		const walk: WalkFn = (value) => {
+			const res = coreWalk(value);
+			for (const [key, ref] of backrefs) {
+				const prev = seen.get(ref);
+				if (!prev) {
+					throw new Error(`Back-reference ${ref.split(nonce).join('.')} not found`);
+				}
+				const path = key.split(nonce);
+				let insertAt = res as any
+				try {
+					while (path.length > 1) {
+						insertAt = insertAt[path.shift()!];
+					}
+					insertAt[path[0]!] = prev
+				} catch (cause) {
+					throw new Error(`Invalid path to back-reference ${ref.split(nonce).join('.')}`, { cause });
+				}
+			}
+			return res
+		}
 
 		return walk;
 	};

--- a/src/sync/deserialize.ts
+++ b/src/sync/deserialize.ts
@@ -37,7 +37,7 @@ export function createTsonDeserialize(opts: TsonOptions): TsonDeserializeFn {
 			const key = path.join(nonce);
 			if (isTsonTuple(value, nonce)) {
 				const [type, serializedValue] = value;
-				if (type === "CIRCULAR") {
+				if (type === "Reference") {
 					references.push([key, serializedValue as string]);
 					return nonce;
 				}

--- a/src/sync/serialize.ts
+++ b/src/sync/serialize.ts
@@ -13,7 +13,7 @@ import {
 	TsonTypeTesterPrimitive,
 } from "./syncTypes.js";
 
-type WalkFn = (value: unknown, path?: (string|number)[]) => unknown;
+type WalkFn = (value: unknown, path?: (number | string)[]) => unknown;
 type WalkerFactory = (nonce: TsonNonce) => WalkFn;
 
 function getHandlers(opts: TsonOptions) {
@@ -56,7 +56,7 @@ export function createTsonSerialize(opts: TsonOptions): TsonSerializeFn {
 	const [getNonce, nonPrimitive, byPrimitive] = getHandlers(opts);
 
 	const walker: WalkerFactory = (nonce) => {
-		const seen = new WeakMap<object, (string|number)[]>();
+		const seen = new WeakMap<object, (number | string)[]>();
 		const cache = new WeakMap<object, unknown>();
 
 		const walk: WalkFn = (value, path = []) => {
@@ -74,14 +74,10 @@ export function createTsonSerialize(opts: TsonOptions): TsonSerializeFn {
 			if (isComplex) {
 				const prev = seen.get(value);
 				if (prev) {
-					return [
-						"CIRCULAR",
-						prev.join(nonce),
-						nonce,
-					] as TsonTuple;
+					return ["CIRCULAR", prev.join(nonce), nonce] as TsonTuple;
 				}
 
-				seen.set(value, path)
+				seen.set(value, path);
 			}
 
 			const primitiveHandler = byPrimitive[type];
@@ -108,7 +104,9 @@ export function createTsonSerialize(opts: TsonOptions): TsonSerializeFn {
 				}
 			}
 
-			return cacheAndReturn(mapOrReturn(value, (value, key) => walk(value, [...path, key])));
+			return cacheAndReturn(
+				mapOrReturn(value, (value, key) => walk(value, [...path, key])),
+			);
 		};
 
 		return walk;

--- a/src/sync/serialize.ts
+++ b/src/sync/serialize.ts
@@ -74,7 +74,7 @@ export function createTsonSerialize(opts: TsonOptions): TsonSerializeFn {
 			if (isComplex) {
 				const prev = seen.get(value);
 				if (prev) {
-					return ["CIRCULAR", prev.join(nonce), nonce] as TsonTuple;
+					return ["Reference", prev.join(nonce), nonce] as TsonTuple;
 				}
 
 				seen.set(value, path);

--- a/src/sync/serialize.ts
+++ b/src/sync/serialize.ts
@@ -1,4 +1,4 @@
-import { TsonCircularReferenceError } from "../errors.js";
+// import { TsonCircularReferenceError } from "../errors.js";
 import { GetNonce, getDefaultNonce } from "../internals/getNonce.js";
 import { mapOrReturn } from "../internals/mapOrReturn.js";
 import {
@@ -13,7 +13,7 @@ import {
 	TsonTypeTesterPrimitive,
 } from "./syncTypes.js";
 
-type WalkFn = (value: unknown) => unknown;
+type WalkFn = (value: unknown, path?: (string|number)[]) => unknown;
 type WalkerFactory = (nonce: TsonNonce) => WalkFn;
 
 function getHandlers(opts: TsonOptions) {
@@ -56,25 +56,12 @@ export function createTsonSerialize(opts: TsonOptions): TsonSerializeFn {
 	const [getNonce, nonPrimitive, byPrimitive] = getHandlers(opts);
 
 	const walker: WalkerFactory = (nonce) => {
-		const seen = new WeakSet();
+		const seen = new WeakMap<object, (string|number)[]>();
 		const cache = new WeakMap<object, unknown>();
 
-		const walk: WalkFn = (value) => {
+		const walk: WalkFn = (value, path = []) => {
 			const type = typeof value;
 			const isComplex = !!value && type === "object";
-
-			if (isComplex) {
-				if (seen.has(value)) {
-					const cached = cache.get(value);
-					if (!cached) {
-						throw new TsonCircularReferenceError(value);
-					}
-
-					return cached;
-				}
-
-				seen.add(value);
-			}
 
 			const cacheAndReturn = (result: unknown) => {
 				if (isComplex) {
@@ -84,6 +71,19 @@ export function createTsonSerialize(opts: TsonOptions): TsonSerializeFn {
 				return result;
 			};
 
+			if (isComplex) {
+				const prev = seen.get(value);
+				if (prev) {
+					return [
+						"CIRCULAR",
+						prev.join(nonce),
+						nonce,
+					] as TsonTuple;
+				}
+
+				seen.set(value, path)
+			}
+
 			const primitiveHandler = byPrimitive[type];
 			if (
 				primitiveHandler &&
@@ -92,7 +92,7 @@ export function createTsonSerialize(opts: TsonOptions): TsonSerializeFn {
 				return cacheAndReturn([
 					primitiveHandler.key,
 					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-					walk(primitiveHandler.serialize!(value)),
+					walk(primitiveHandler.serialize!(value), path),
 					nonce,
 				] as TsonTuple);
 			}
@@ -102,13 +102,13 @@ export function createTsonSerialize(opts: TsonOptions): TsonSerializeFn {
 					return cacheAndReturn([
 						handler.key,
 						// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-						walk(handler.serialize!(value)),
+						walk(handler.serialize!(value), path),
 						nonce,
 					] as TsonTuple);
 				}
 			}
 
-			return cacheAndReturn(mapOrReturn(value, walk));
+			return cacheAndReturn(mapOrReturn(value, (value, key) => walk(value, [...path, key])));
 		};
 
 		return walk;


### PR DESCRIPTION
DISCLAIMERS: 
- this PR is a POC, code isn't very clean (the reference handling is done directly in the walkers, and not in its own neat plugin). 
- this PR was just a toy idea initially, there is absolutely no issue with simply throwing the code away

---

Add support for back-references:
- support preserving identity of objects
  ```ts
  const a = {}
  const data = {
    foo: a,
    bar: a,
  }
  const res = tson.parse(tson.stringify(data))
  res.foo === res.bar // true
  ```
- support circular references
  ```ts
  const data = {}
  data.foo = data
  const res = tson.parse(tson.stringify(data))
  data === data.foo // true
  ```

This PR also includes
- changes in benchmark
  - use `Intl.NumberFormat` to format results
  - use `process.memoryUsage` to also log memory information (though I'm not sure how to interpret it, nor whether it's actually useful...)

This PR does not include
- changes to async methods (serialize / deserialize) to enable back-references in these cases too