### PR TITLE
fix: use error constructor params and spread them

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,9 +1,6 @@
-// get constructor parameters of Error
-type ErrorOptions = ConstructorParameters<typeof Error>[1];
-
 export class TsonError extends Error {
-	constructor(message: string, opts?: ErrorOptions) {
-		super(message, opts);
+	constructor(...args: ConstructorParameters<typeof Error>) {
+		super(...args);
 		this.name = "TsonError";
 	}
 }


### PR DESCRIPTION
fixes https://github.com/trpc/trpc/actions/runs/6502317199/job/17661147661?pr=4911

> @examples/soa:build: ../../node_modules/.pnpm/tupleson@0.17.0/node_modules/tupleson/lib/errors.d.ts(1,57): error TS2493: Tuple type '[message?: string | undefined]' of length '1' has no element at index '1'.