### PR TITLE
fix: close event-source connection when response is complete

### DIFF
--- a/examples/sse/src/app/StreamedTime.tsx
+++ b/examples/sse/src/app/StreamedTime.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 
-import type { ResponseShape } from "./api/sse/route";
+import type { ResponseShape } from "./api/sse/infinite/route";
 
 import { createEventSource } from "./tsonOptions";
 
@@ -10,7 +10,7 @@ export function StreamedTime() {
 	const [time, setTime] = useState("....");
 	useEffect(() => {
 		const abortSignal = new AbortController();
-		createEventSource<ResponseShape>("/api/sse", {
+		createEventSource<ResponseShape>("/api/sse/infinite", {
 			signal: abortSignal.signal,
 		})
 			.then(async (shape) => {

--- a/examples/sse/src/app/StreamedTime.tsx
+++ b/examples/sse/src/app/StreamedTime.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 
 import type { ResponseShape } from "./api/sse/infinite/route";
 
-import { createEventSource } from "./tsonOptions";
+import { createEventSource, isAbortError } from "./tsonOptions";
 
 export function StreamedTime() {
 	const [time, setTime] = useState("....");
@@ -19,7 +19,11 @@ export function StreamedTime() {
 				}
 			})
 			.catch((err) => {
-				console.error(err);
+				if (isAbortError(err)) {
+					console.log("aborted - might be React doing its double render thing");
+				} else {
+					console.error(err);
+				}
 			});
 
 		return () => {

--- a/examples/sse/src/app/StreamedTime.tsx
+++ b/examples/sse/src/app/StreamedTime.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 
 import type { ResponseShape } from "./api/sse/infinite/route";
 
-import { createEventSource, isAbortError } from "./tsonOptions";
+import { createEventSource } from "./tsonOptions";
 
 export function StreamedTime() {
 	const [time, setTime] = useState("....");
@@ -19,11 +19,7 @@ export function StreamedTime() {
 				}
 			})
 			.catch((err) => {
-				if (isAbortError(err)) {
-					console.log("aborted - might be React doing its double render thing");
-				} else {
-					console.error(err);
-				}
+				console.error(err);
 			});
 
 		return () => {

--- a/examples/sse/src/app/StreamedTuple.tsx
+++ b/examples/sse/src/app/StreamedTuple.tsx
@@ -4,7 +4,7 @@ import { Fragment, useEffect, useState } from "react";
 
 import type { ResponseShape } from "./api/sse/finite/route";
 
-import { createEventSource } from "./tsonOptions";
+import { createEventSource, isAbortError } from "./tsonOptions";
 
 export function StreamedTuple() {
 	const [list, setList] = useState<null | number[]>(null);
@@ -20,7 +20,11 @@ export function StreamedTuple() {
 				}
 			})
 			.catch((err) => {
-				console.error(err);
+				if (isAbortError(err)) {
+					console.log("aborted - might be React doing its double render thing");
+				} else {
+					console.error(err);
+				}
 			});
 
 		return () => {

--- a/examples/sse/src/app/StreamedTuple.tsx
+++ b/examples/sse/src/app/StreamedTuple.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import type { ResponseShape } from "./api/sse/finite/route";
+
+import { createEventSource } from "./tsonOptions";
+
+export function StreamedTuple() {
+	const [list, setList] = useState<number[]>([]);
+
+	const handleStream = useCallback(() => {
+		const abortSignal = new AbortController();
+		createEventSource<ResponseShape>("/api/sse/finite", {
+			signal: abortSignal.signal,
+		})
+			.then(async (shape) => {
+				for await (const item of shape.finiteListGenerator) {
+					if (item === undefined) {
+						throw new Error("item is undefined");
+					}
+
+					setList((list) => [...list, item]);
+				}
+			})
+			.catch((err) => {
+				console.error(err);
+			});
+	}, []);
+
+	return (
+		<div
+			style={{
+				alignItems: "center",
+				display: "flex",
+				flexDirection: "column",
+			}}
+		>
+			<button onClick={handleStream}>Stream</button>
+			<div
+				style={{
+					display: "flex",
+					flexDirection: "row",
+					flexWrap: "wrap",
+					justifyContent: "center",
+				}}
+			>
+				{list.map((item, index) => (
+					<div key={index}>{item}</div>
+				))}
+			</div>
+		</div>
+	);
+}

--- a/examples/sse/src/app/StreamedTuple.tsx
+++ b/examples/sse/src/app/StreamedTuple.tsx
@@ -1,41 +1,54 @@
 "use client";
 
-import { Fragment, useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import type { ResponseShape } from "./api/sse/finite/route";
 
-import { createEventSource, isAbortError } from "./tsonOptions";
+import { createEventSource } from "./tsonOptions";
 
 export function StreamedTuple() {
-	const [list, setList] = useState<null | number[]>(null);
+	const [list, setList] = useState<number[]>([]);
 
-	useEffect(() => {
+	const handleStream = useCallback(() => {
 		const abortSignal = new AbortController();
 		createEventSource<ResponseShape>("/api/sse/finite", {
 			signal: abortSignal.signal,
 		})
 			.then(async (shape) => {
-				for await (const time of shape.finiteListGenerator) {
-					setList((list) => [...(list ?? []), time]);
+				for await (const item of shape.finiteListGenerator) {
+					if (item === undefined) {
+						throw new Error("item is undefined");
+					}
+
+					setList((list) => [...list, item]);
 				}
 			})
 			.catch((err) => {
-				if (isAbortError(err)) {
-					console.log("aborted - might be React doing its double render thing");
-				} else {
-					console.error(err);
-				}
+				console.error(err);
 			});
-
-		return () => {
-			abortSignal.abort();
-		};
 	}, []);
 
 	return (
-		<>
-			{list?.map((item, index) => <Fragment key={index}>{item}</Fragment>) ??
-				"...."}
-		</>
+		<div
+			style={{
+				alignItems: "center",
+				display: "flex",
+				flexDirection: "column",
+			}}
+		>
+			<button onClick={handleStream}>Stream</button>
+			<div
+				style={{
+					display: "flex",
+					flexDirection: "row",
+					flexWrap: "wrap",
+					justifyContent: "center",
+				}}
+			>
+				{list.map((item, index) => (
+					<div key={index}>{item}</div>
+				))}
+			</div>
+		</div>
 	);
 }

--- a/examples/sse/src/app/StreamedTuple.tsx
+++ b/examples/sse/src/app/StreamedTuple.tsx
@@ -1,54 +1,37 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { Fragment, useEffect, useState } from "react";
 
 import type { ResponseShape } from "./api/sse/finite/route";
 
 import { createEventSource } from "./tsonOptions";
 
 export function StreamedTuple() {
-	const [list, setList] = useState<number[]>([]);
+	const [list, setList] = useState<null | number[]>(null);
 
-	const handleStream = useCallback(() => {
+	useEffect(() => {
 		const abortSignal = new AbortController();
 		createEventSource<ResponseShape>("/api/sse/finite", {
 			signal: abortSignal.signal,
 		})
 			.then(async (shape) => {
-				for await (const item of shape.finiteListGenerator) {
-					if (item === undefined) {
-						throw new Error("item is undefined");
-					}
-
-					setList((list) => [...list, item]);
+				for await (const time of shape.finiteListGenerator) {
+					setList((list) => [...(list ?? []), time]);
 				}
 			})
 			.catch((err) => {
 				console.error(err);
 			});
+
+		return () => {
+			abortSignal.abort();
+		};
 	}, []);
 
 	return (
-		<div
-			style={{
-				alignItems: "center",
-				display: "flex",
-				flexDirection: "column",
-			}}
-		>
-			<button onClick={handleStream}>Stream</button>
-			<div
-				style={{
-					display: "flex",
-					flexDirection: "row",
-					flexWrap: "wrap",
-					justifyContent: "center",
-				}}
-			>
-				{list.map((item, index) => (
-					<div key={index}>{item}</div>
-				))}
-			</div>
-		</div>
+		<>
+			{list?.map((item, index) => <Fragment key={index}>{item}</Fragment>) ??
+				"...."}
+		</>
 	);
 }

--- a/examples/sse/src/app/StreamedTuple.tsx
+++ b/examples/sse/src/app/StreamedTuple.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 
 import type { ResponseShape } from "./api/sse/finite/route";
 

--- a/examples/sse/src/app/api/sse/finite/route.ts
+++ b/examples/sse/src/app/api/sse/finite/route.ts
@@ -1,4 +1,4 @@
-import { createSSEResponse } from "../../tsonOptions";
+import { createSSEResponse } from "../../../tsonOptions";
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -6,21 +6,16 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
  * This function returns the object we will be sending to the client.
  */
 export function getResponseShape() {
-	async function* currentTimeGenerator() {
-		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-		while (true) {
-			yield new Intl.DateTimeFormat("en-US", {
-				hour: "numeric",
-				hour12: false,
-				minute: "numeric",
-				second: "numeric",
-			}).format(new Date());
+	const tuple = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0];
+	async function* finiteListGenerator() {
+		while (tuple.length) {
+			yield tuple.shift();
 			await sleep(500);
 		}
 	}
 
 	return {
-		currentTimeGenerator: currentTimeGenerator(),
+		finiteListGenerator: finiteListGenerator(),
 	};
 }
 

--- a/examples/sse/src/app/api/sse/finite/route.ts
+++ b/examples/sse/src/app/api/sse/finite/route.ts
@@ -6,10 +6,10 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
  * This function returns the object we will be sending to the client.
  */
 export function getResponseShape() {
-	let i = 0;
+	const tuple = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0];
 	async function* finiteListGenerator() {
-		while (i < 10) {
-			yield i++;
+		while (tuple.length) {
+			yield tuple.shift();
 			await sleep(500);
 		}
 	}

--- a/examples/sse/src/app/api/sse/finite/route.ts
+++ b/examples/sse/src/app/api/sse/finite/route.ts
@@ -6,10 +6,10 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
  * This function returns the object we will be sending to the client.
  */
 export function getResponseShape() {
-	const tuple = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0];
+	let i = 0;
 	async function* finiteListGenerator() {
-		while (tuple.length) {
-			yield tuple.shift();
+		while (i < 10) {
+			yield i++;
 			await sleep(500);
 		}
 	}

--- a/examples/sse/src/app/api/sse/infinite/route.ts
+++ b/examples/sse/src/app/api/sse/infinite/route.ts
@@ -1,0 +1,33 @@
+import { createSSEResponse } from "../../../tsonOptions";
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * This function returns the object we will be sending to the client.
+ */
+export function getResponseShape() {
+	async function* currentTimeGenerator() {
+		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+		while (true) {
+			yield new Intl.DateTimeFormat("en-US", {
+				hour: "numeric",
+				hour12: false,
+				minute: "numeric",
+				second: "numeric",
+			}).format(new Date());
+			await sleep(500);
+		}
+	}
+
+	return {
+		currentTimeGenerator: currentTimeGenerator(),
+	};
+}
+
+export type ResponseShape = ReturnType<typeof getResponseShape>;
+
+export function GET() {
+	const res = createSSEResponse(getResponseShape());
+
+	return res;
+}

--- a/examples/sse/src/app/page.tsx
+++ b/examples/sse/src/app/page.tsx
@@ -7,29 +7,12 @@ import { StreamedTuple } from "./StreamedTuple";
  */
 export default function Page() {
 	return (
-		<section className="flex flex-col h-screen justify-center items-center bg-gray-100 dark:bg-gray-800 space-y-6">
-			<div className="space-y-2">
-				<div className="space-y-2">
-					<h2 className="text-2xl text-center text-gray-800 dark:text-gray-200">
-						Infinite stream
-					</h2>
-					<div className="bg-white dark:bg-gray-900 p-8 rounded-xl shadow-md">
-						<div className="text-2xl text-center text-gray-800 dark:text-gray-200 font-mono">
-							<StreamedTime />
-						</div>
-					</div>
-				</div>
-			</div>
-
-			<div className="space-y-2">
-				<h2 className="text-2xl text-center text-gray-800 dark:text-gray-200">
-					Finite stream
-				</h2>
-				<div className="bg-white dark:bg-gray-900 p-8 rounded-xl shadow-md">
-					<div className="text-2xl text-center text-gray-800 dark:text-gray-200 font-mono">
-						<StreamedTuple />
-					</div>
-				</div>
+		<section className="flex h-screen justify-center items-center bg-gray-100 dark:bg-gray-800">
+			<div className="bg-white dark:bg-gray-900 p-8 rounded-xl shadow-md">
+				<h1 className="text-2xl text-center text-gray-800 dark:text-gray-200 font-mono">
+					<StreamedTime />
+					<StreamedTuple />
+				</h1>
 			</div>
 		</section>
 	);

--- a/examples/sse/src/app/page.tsx
+++ b/examples/sse/src/app/page.tsx
@@ -7,12 +7,29 @@ import { StreamedTuple } from "./StreamedTuple";
  */
 export default function Page() {
 	return (
-		<section className="flex h-screen justify-center items-center bg-gray-100 dark:bg-gray-800">
-			<div className="bg-white dark:bg-gray-900 p-8 rounded-xl shadow-md">
-				<h1 className="text-2xl text-center text-gray-800 dark:text-gray-200 font-mono">
-					<StreamedTime />
-					<StreamedTuple />
-				</h1>
+		<section className="flex flex-col h-screen justify-center items-center bg-gray-100 dark:bg-gray-800 space-y-6">
+			<div className="space-y-2">
+				<div className="space-y-2">
+					<h2 className="text-2xl text-center text-gray-800 dark:text-gray-200">
+						Infinite stream
+					</h2>
+					<div className="bg-white dark:bg-gray-900 p-8 rounded-xl shadow-md">
+						<div className="text-2xl text-center text-gray-800 dark:text-gray-200 font-mono">
+							<StreamedTime />
+						</div>
+					</div>
+				</div>
+			</div>
+
+			<div className="space-y-2">
+				<h2 className="text-2xl text-center text-gray-800 dark:text-gray-200">
+					Finite stream
+				</h2>
+				<div className="bg-white dark:bg-gray-900 p-8 rounded-xl shadow-md">
+					<div className="text-2xl text-center text-gray-800 dark:text-gray-200 font-mono">
+						<StreamedTuple />
+					</div>
+				</div>
 			</div>
 		</section>
 	);

--- a/examples/sse/src/app/page.tsx
+++ b/examples/sse/src/app/page.tsx
@@ -1,4 +1,5 @@
 import { StreamedTime } from "./StreamedTime";
+import { StreamedTuple } from "./StreamedTuple";
 
 /**
  * v0 by Vercel.
@@ -10,6 +11,7 @@ export default function Page() {
 			<div className="bg-white dark:bg-gray-900 p-8 rounded-xl shadow-md">
 				<h1 className="text-2xl text-center text-gray-800 dark:text-gray-200 font-mono">
 					<StreamedTime />
+					<StreamedTuple />
 				</h1>
 			</div>
 		</section>

--- a/examples/sse/src/app/tsonOptions.ts
+++ b/examples/sse/src/app/tsonOptions.ts
@@ -1,5 +1,4 @@
 import {
-	TsonAbortError,
 	TsonAsyncOptions,
 	createTsonParseEventSource,
 	createTsonSSEResponse,
@@ -24,10 +23,3 @@ export const tsonOptions: TsonAsyncOptions = {
 };
 export const createSSEResponse = createTsonSSEResponse(tsonOptions);
 export const createEventSource = createTsonParseEventSource(tsonOptions);
-
-export function isAbortError(err: unknown): err is TsonAbortError {
-	return (
-		err instanceof TsonAbortError ||
-		(err instanceof Error && err.cause === TsonAbortError)
-	);
-}

--- a/examples/sse/src/app/tsonOptions.ts
+++ b/examples/sse/src/app/tsonOptions.ts
@@ -1,4 +1,5 @@
 import {
+	TsonAbortError,
 	TsonAsyncOptions,
 	createTsonParseEventSource,
 	createTsonSSEResponse,
@@ -23,3 +24,10 @@ export const tsonOptions: TsonAsyncOptions = {
 };
 export const createSSEResponse = createTsonSSEResponse(tsonOptions);
 export const createEventSource = createTsonParseEventSource(tsonOptions);
+
+export function isAbortError(err: unknown): err is TsonAbortError {
+	return (
+		err instanceof TsonAbortError ||
+		(err instanceof Error && err.cause === TsonAbortError)
+	);
+}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 	],
 	"scripts": {
 		"build": "tsup",
+		"dev": "tsup --watch",
 		"fix": "pnpm lint --fix && pnpm format:write",
 		"format": "prettier \"**/*\" --ignore-unknown",
 		"format:write": "pnpm format --write",

--- a/src/async/deserializeAsync.test.ts
+++ b/src/async/deserializeAsync.test.ts
@@ -734,21 +734,18 @@ test("e2e: client aborted request", async () => {
 		}
 
 		expect(results).toEqual([0, 1, 2, 3, 4, 5]);
-		expect(iteratorError).toMatchInlineSnapshot(
-			"[TsonStreamInterruptedError: Stream interrupted: The operation was aborted.]",
-		);
+		expect(iteratorError).toMatch(/operation was aborted/);
 	}
 
 	expect(parseOptions.onStreamError).toHaveBeenCalledTimes(1);
 
 	const streamError = parseOptions.onStreamError.mock.calls[0]![0]!;
-	expect(streamError).toMatchInlineSnapshot(
-		"[TsonStreamInterruptedError: Stream interrupted: The operation was aborted.]",
-	);
 
-	expect(streamError.cause).toMatchInlineSnapshot(
-		"[AbortError: The operation was aborted.]",
-	);
+	expect(streamError).toMatch(/operation was aborted/);
+
+	assert(streamError.cause instanceof Error);
+	expect(streamError.cause.message).toMatch(/operation was aborted/);
+	expect(streamError.cause.name).toMatchInlineSnapshot('"AbortError"');
 
 	expect(iteratorChunks.length).toBeLessThan(10);
 	expect(iteratorChunks).toMatchInlineSnapshot(`

--- a/src/async/deserializeAsync.test.ts
+++ b/src/async/deserializeAsync.test.ts
@@ -735,7 +735,7 @@ test("e2e: client aborted request", async () => {
 
 		expect(results).toEqual([0, 1, 2, 3, 4, 5]);
 		expect(iteratorError).toMatchInlineSnapshot(
-			"[TsonStreamInterruptedError: Stream interrupted: This operation was aborted]",
+			"[TsonStreamInterruptedError: Stream interrupted: The operation was aborted.]",
 		);
 	}
 
@@ -743,11 +743,11 @@ test("e2e: client aborted request", async () => {
 
 	const streamError = parseOptions.onStreamError.mock.calls[0]![0]!;
 	expect(streamError).toMatchInlineSnapshot(
-		"[TsonStreamInterruptedError: Stream interrupted: This operation was aborted]",
+		"[TsonStreamInterruptedError: Stream interrupted: The operation was aborted.]",
 	);
 
 	expect(streamError.cause).toMatchInlineSnapshot(
-		"[AbortError: This operation was aborted]",
+		"[AbortError: The operation was aborted.]",
 	);
 
 	expect(iteratorChunks.length).toBeLessThan(10);

--- a/src/async/deserializeAsync.test.ts
+++ b/src/async/deserializeAsync.test.ts
@@ -735,7 +735,7 @@ test("e2e: client aborted request", async () => {
 
 		expect(results).toEqual([0, 1, 2, 3, 4, 5]);
 		expect(iteratorError).toMatchInlineSnapshot(
-			'[TsonStreamInterruptedError: Stream interrupted: This operation was aborted]',
+			"[TsonStreamInterruptedError: Stream interrupted: This operation was aborted]",
 		);
 	}
 
@@ -743,11 +743,11 @@ test("e2e: client aborted request", async () => {
 
 	const streamError = parseOptions.onStreamError.mock.calls[0]![0]!;
 	expect(streamError).toMatchInlineSnapshot(
-		'[TsonStreamInterruptedError: Stream interrupted: This operation was aborted]',
+		"[TsonStreamInterruptedError: Stream interrupted: This operation was aborted]",
 	);
 
 	expect(streamError.cause).toMatchInlineSnapshot(
-		'[AbortError: This operation was aborted]',
+		"[AbortError: This operation was aborted]",
 	);
 
 	expect(iteratorChunks.length).toBeLessThan(10);

--- a/src/async/deserializeAsync.test.ts
+++ b/src/async/deserializeAsync.test.ts
@@ -735,7 +735,7 @@ test("e2e: client aborted request", async () => {
 
 		expect(results).toEqual([0, 1, 2, 3, 4, 5]);
 		expect(iteratorError).toMatchInlineSnapshot(
-			"[TsonStreamInterruptedError: Stream interrupted: The operation was aborted.]",
+			'[TsonStreamInterruptedError: Stream interrupted: This operation was aborted]',
 		);
 	}
 
@@ -743,11 +743,11 @@ test("e2e: client aborted request", async () => {
 
 	const streamError = parseOptions.onStreamError.mock.calls[0]![0]!;
 	expect(streamError).toMatchInlineSnapshot(
-		"[TsonStreamInterruptedError: Stream interrupted: The operation was aborted.]",
+		'[TsonStreamInterruptedError: Stream interrupted: This operation was aborted]',
 	);
 
 	expect(streamError.cause).toMatchInlineSnapshot(
-		"[AbortError: The operation was aborted.]",
+		'[AbortError: This operation was aborted]',
 	);
 
 	expect(iteratorChunks.length).toBeLessThan(10);

--- a/src/async/deserializeAsync.ts
+++ b/src/async/deserializeAsync.ts
@@ -285,8 +285,12 @@ export function createTsonParseEventSource(opts: TsonAsyncOptions) {
 		signal?.addEventListener("abort", onAbort);
 
 		eventSource.onmessage = (msg) => {
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-			controller.enqueue(JSON.parse(msg.data));
+			if (msg.data === '["__tson_disconnect"]') {
+				eventSource.close();
+			} else {
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+				controller.enqueue(JSON.parse(msg.data));
+			}
 		};
 
 		const iterable = readableStreamToAsyncIterable(stream);

--- a/src/async/deserializeAsync.ts
+++ b/src/async/deserializeAsync.ts
@@ -284,14 +284,18 @@ export function createTsonParseEventSource(opts: TsonAsyncOptions) {
 
 		signal?.addEventListener("abort", onAbort);
 
-		eventSource.onmessage = (msg) => {
-			if (msg.data === '["__tson_disconnect"]') {
-				eventSource.close();
-			}
+		// eventSource.addEventListener("head", (e) => {
+		// 	controller.enqueue(JSON.parse(e.data));
+		// });
 
+		eventSource.onmessage = (msg) => {
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
 			controller.enqueue(JSON.parse(msg.data));
 		};
+
+		eventSource.addEventListener("close", () => {
+			controller.close();
+		});
 
 		const iterable = readableStreamToAsyncIterable(stream);
 		return (await instance(iterable, parseOpts)) as TValue;

--- a/src/async/deserializeAsync.ts
+++ b/src/async/deserializeAsync.ts
@@ -287,10 +287,10 @@ export function createTsonParseEventSource(opts: TsonAsyncOptions) {
 		eventSource.onmessage = (msg) => {
 			if (msg.data === '["__tson_disconnect"]') {
 				eventSource.close();
-			} else {
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-				controller.enqueue(JSON.parse(msg.data));
 			}
+
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+			controller.enqueue(JSON.parse(msg.data));
 		};
 
 		const iterable = readableStreamToAsyncIterable(stream);

--- a/src/async/iterableUtils.ts
+++ b/src/async/iterableUtils.ts
@@ -48,6 +48,17 @@ export function createReadableStream<TValue = unknown>() {
 	return [stream, controller] as const;
 }
 
+/**
+ * Creates an event that adheres to the [Event Stream format](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event_stream_format)
+ * 
+ * When called without any arguments, it returns a keep-alive event.
+ * @param opts {{ data?: TData; event?: TEvent; id?: TId; retry?: TRetry }}
+ * @param opts.data The data to send to the client. This value will be seriaized to JSON.
+ * @param opts.event The type of event to send to the client. Defaults to `message`.
+ * @param opts.id The id of the event to send to the client, used to resume the connection.
+ * @param opts.retry The reconnection time. If the connection to the server is lost, the
+ * browser will wait for the specified time before attempting to reconnect.
+ */
 export function createServerEvent<
 	const TData,
 	const TEvent extends string,

--- a/src/async/iterableUtils.ts
+++ b/src/async/iterableUtils.ts
@@ -1,3 +1,5 @@
+import type { TsonSerialized } from "../sync/syncTypes.js";
+
 import { assert } from "../internals/assert.js";
 
 export async function* readableStreamToAsyncIterable<T>(
@@ -46,4 +48,80 @@ export function createReadableStream<TValue = unknown>() {
 	assert(controller, `Could not find controller - this is a bug`);
 
 	return [stream, controller] as const;
+}
+
+export function createServerEvent<
+	const TData,
+	const TEvent extends string,
+	const TId extends string,
+	const TRetry extends number,
+>(opts: {
+	data?: TData;
+	/**
+	 * The type of event to send to the client. Defaults to `message`.
+	 * @default "message" when any other field is set, undefined otherwise
+	 * @example ```ts
+	 *  /// on the server
+	 * createServerEvent({ event: "answer", data: 42 })
+	 * createServerEvent({ event: "close" })
+	 * /// on the client
+	 * const eventSource = new EventSource("/sse");
+	 * let answer;
+	 * eventSource.addEventListener("answer", (e) => {
+	 * 	answer = e.data;
+	 * })
+	 * eventSource.addEventListener("close", () => {
+	 * 	eventSource.close();
+	 * })
+	 * ```
+	 */
+	event?: TEvent;
+	/**
+	 * The id of the event to send to the client, used to resume the connection.
+	 * When the EventSource client reconnects, it will send the last id it
+	 * received via the `Last-Event-ID` header (though the header can also be
+	 * set manually). The server will then resume the connection and send all
+	 * events that happened since the last event with that id.
+	 * @default undefined
+	 */
+	id?: TId;
+	/**
+	 * The reconnection time. If the connection to the server is lost, the
+	 * browser will wait for the specified time before attempting to reconnect.
+	 * This must be an integer, specifying the reconnection time in
+	 * milliseconds. If a non-integer value is specified it will be rounded
+	 * down to the nearest integer. The default value is 1000 ms (1 second).
+	 */
+	retry?: TRetry;
+}): string {
+	const { data, event, id, retry } = opts;
+
+	// Lines starting with a colon are essentially comments, and are ignored.
+	// An event consisting solely of a comment is equivalent to a keep-alive.
+	// By setting
+	const emptyLine = ":\n";
+
+	return (
+		emptyLine +
+		addIfProvided("event", event) +
+		addIfProvided("id", id) +
+		addIfProvided("retry", retry) +
+		addIfProvided("data", data) +
+		"\n"
+	);
+}
+
+function addIfProvided<TKey extends "data" | "event" | "id" | "retry">(
+	key: TKey,
+	value: Parameters<typeof createServerEvent>[0][TKey],
+) {
+	if (value === undefined) {
+		return "";
+	}
+
+	if (key === "data") {
+		return `data: ${JSON.stringify(value)}\n`;
+	}
+
+	return `${key}: ${value as any}\n`;
 }

--- a/src/async/iterableUtils.ts
+++ b/src/async/iterableUtils.ts
@@ -50,10 +50,10 @@ export function createReadableStream<TValue = unknown>() {
 
 /**
  * Creates an event that adheres to the [Event Stream format](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event_stream_format)
- * 
+ *
  * When called without any arguments, it returns a keep-alive event.
  * @param opts {{ data?: TData; event?: TEvent; id?: TId; retry?: TRetry }}
- * @param opts.data The data to send to the client. This value will be seriaized to JSON.
+ * @param opts.data The data to send to the client. This value will be serialized to JSON.
  * @param opts.event The type of event to send to the client. Defaults to `message`.
  * @param opts.id The id of the event to send to the client, used to resume the connection.
  * @param opts.retry The reconnection time. If the connection to the server is lost, the

--- a/src/async/iterableUtils.ts
+++ b/src/async/iterableUtils.ts
@@ -1,5 +1,3 @@
-import type { TsonSerialized } from "../sync/syncTypes.js";
-
 import { assert } from "../internals/assert.js";
 
 export async function* readableStreamToAsyncIterable<T>(

--- a/src/async/serializeAsync.ts
+++ b/src/async/serializeAsync.ts
@@ -264,6 +264,12 @@ export function createTsonSSEResponse(opts: TsonAsyncOptions) {
 				controller.enqueue(`data: ${JSON.stringify(chunk)}\n\n`);
 			}
 
+			// indicate the end of the stream
+
+			controller.enqueue(`data: ["__tson_disconnect"]\n\n`);
+
+			controller.close();
+
 			controller.error(
 				new TsonStreamInterruptedError(new Error("SSE stream ended")),
 			);
@@ -278,6 +284,8 @@ export function createTsonSSEResponse(opts: TsonAsyncOptions) {
 				"Cache-Control": "no-cache",
 				Connection: "keep-alive",
 				"Content-Type": "text/event-stream",
+				// prevent buffering by nginx
+				"X-Accel-Buffering": "no",
 			},
 			status: 200,
 		});


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to tson! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/trpc/tupleson/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/trpc/tupleson/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

The server now sends a 'disconnect' message once an SSE response's iterator is exhausted (if ever). The client deserializer responds by closing the event-source.

> [!NOTE]
> Yes, I know this video shows an error where the final item ("0") is dropped. It is now fixed, I'm just too lazy to re-record the demo :)

https://github.com/trpc/tupleson/assets/66281141/e6e65d8e-bdc7-4644-bb50-8f95b324f990

