### PR TITLE
feat: expose TsonSerialized type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,11 @@ export { createTson } from "./sync/createTson.js";
 export { createTsonDeserialize, createTsonParser } from "./sync/deserialize.js";
 export { createTsonSerialize, createTsonStringify } from "./sync/serialize.js";
 export type { TsonType } from "./sync/syncTypes.js";
-export type { TsonOptions, TsonSerialized, TsonStringified } from "./sync/syncTypes.js";
+export type {
+	TsonOptions,
+	TsonSerialized,
+	TsonStringified,
+} from "./sync/syncTypes.js";
 
 // type handlers
 export * from "./sync/handlers/tsonBigint.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ export { createTson } from "./sync/createTson.js";
 export { createTsonDeserialize, createTsonParser } from "./sync/deserialize.js";
 export { createTsonSerialize, createTsonStringify } from "./sync/serialize.js";
 export type { TsonType } from "./sync/syncTypes.js";
-export type { TsonOptions } from "./sync/syncTypes.js";
+export type { TsonOptions, TsonSerialized, TsonStringified } from "./sync/syncTypes.js";
 
 // type handlers
 export * from "./sync/handlers/tsonBigint.js";

--- a/src/sync/syncTypes.ts
+++ b/src/sync/syncTypes.ts
@@ -123,7 +123,7 @@ export type TsonDeserializeFn = <TValue>(
 	data: TsonSerialized<TValue>,
 ) => TValue;
 
-type TsonStringified<TValue> = string & { [serialized]: TValue };
+export type TsonStringified<TValue> = string & { [serialized]: TValue };
 
 export type TsonStringifyFn = <TValue>(
 	obj: TValue,


### PR DESCRIPTION
usecase:

```ts
// server component
function SC() {
  const someobj = new Map<string, string>()

  return <CC obj={tson.serialize(someobj)} />
}

// client component
function CC(props: {
  someobj: TsonSerialized<Map<string, string>>;
}) {
  const someobj = tson.deserialize(props.someobj)

  // ...
}
```