### PR TITLE
feat: tsonAsyncGeneratorFunction proposal

### DIFF
--- a/src/async/deserializeAsync.test.ts
+++ b/src/async/deserializeAsync.test.ts
@@ -5,10 +5,10 @@ import {
 	TsonParseAsyncOptions,
 	TsonType,
 	createTsonParseAsync,
+	tsonAsyncGeneratorFunction,
 	tsonAsyncIterable,
 	tsonBigint,
 	tsonPromise,
-	tsonAsyncGeneratorFunction,
 } from "../index.js";
 import { assert } from "../internals/assert.js";
 import {
@@ -93,7 +93,7 @@ test("deserialize async iterable", async () => {
 	}
 });
 
-test.only("stringify async iterable + promise + async generator function", async () => {
+test("stringify async iterable + promise + async generator function", async () => {
 	const tson = createTsonAsync({
 		nonce: () => "__tson",
 		types: [tsonAsyncIterable, tsonPromise, tsonBigint, tsonAsyncGeneratorFunction],
@@ -117,9 +117,9 @@ test.only("stringify async iterable + promise + async generator function", async
 
 	const input = {
 		foo: "bar",
+		generator,
 		iterable: generator(),
 		promise: Promise.resolve(42),
-		generator,
 	};
 
 	const strIterable = tson.stringifyJsonStream(input);
@@ -134,6 +134,7 @@ test.only("stringify async iterable + promise + async generator function", async
 	for await (const value of output.iterable) {
 		iteratorResult.push(value);
 	}
+
 	expect(iteratorResult).toEqual([1n, 2n, 3n, 4n, 5n]);
 
 	const generatorResult1 = [];
@@ -141,6 +142,7 @@ test.only("stringify async iterable + promise + async generator function", async
 	for await (const value of iterator1) {
 		generatorResult1.push(value);
 	}
+
 	expect(generatorResult1).toEqual([1n, 2n, 3n, 4n, 5n]);
 	
 	// generator should be able to be iterated again
@@ -149,6 +151,7 @@ test.only("stringify async iterable + promise + async generator function", async
 	for await (const value of iterator2) {
 		generatorResult2.push(value);
 	}
+
 	expect(generatorResult2).toEqual([1n, 2n, 3n, 4n, 5n]);
 });
 

--- a/src/async/deserializeAsync.test.ts
+++ b/src/async/deserializeAsync.test.ts
@@ -96,7 +96,12 @@ test("deserialize async iterable", async () => {
 test("stringify async iterable + promise + async generator function", async () => {
 	const tson = createTsonAsync({
 		nonce: () => "__tson",
-		types: [tsonAsyncIterable, tsonPromise, tsonBigint, tsonAsyncGeneratorFunction],
+		types: [
+			tsonAsyncIterable,
+			tsonPromise,
+			tsonBigint,
+			tsonAsyncGeneratorFunction,
+		],
 	});
 
 	const parseOptions = {
@@ -144,7 +149,7 @@ test("stringify async iterable + promise + async generator function", async () =
 	}
 
 	expect(generatorResult1).toEqual([1n, 2n, 3n, 4n, 5n]);
-	
+
 	// generator should be able to be iterated again
 	const generatorResult2 = [];
 	const iterator2 = output.generator();

--- a/src/async/handlers/tsonAsyncGeneratorFunction.ts
+++ b/src/async/handlers/tsonAsyncGeneratorFunction.ts
@@ -1,0 +1,128 @@
+import {
+	TsonAbortError,
+	TsonPromiseRejectionError,
+	TsonStreamInterruptedError,
+} from "../asyncErrors.js";
+import { TsonAsyncType } from "../asyncTypes.js";
+
+const ITERATOR_VALUE = 0;
+const ITERATOR_ERROR = 1;
+const ITERATOR_DONE = 2;
+type SerializedIterableResult =
+	| [typeof ITERATOR_DONE]
+	| [typeof ITERATOR_ERROR, unknown]
+	| [typeof ITERATOR_VALUE, unknown];
+
+function isAsyncGeneratorFunction(value: unknown): value is () => AsyncGenerator<unknown, void, unknown> {
+	return (
+		!!value &&
+		typeof value === "function" &&
+		value.prototype[Symbol.toStringTag] === "AsyncGenerator"
+	);
+}
+
+export const tsonAsyncGeneratorFunction: TsonAsyncType<
+	() => AsyncGenerator<unknown, void, unknown>,
+	SerializedIterableResult
+> = {
+	async: true,
+	deserialize: (opts) => {
+		// each value is stored in RAM for generator to be iterated many times
+		const chunks: Exclude<Awaited<ReturnType<(typeof opts.reader)["read"]>>['value'], undefined>[] = []
+		// we need to know if stream is done or just waiting, so that generator can stop looping
+		let collectionDone = false
+		// if generator is being iterated while data is still being collected, we need to be able to wait on the next chunks
+		let resolveNext: () => void
+		let promiseNext = new Promise<void>(resolve => resolveNext = resolve)
+
+		/**
+		 * Collects chunks from the stream until it's done
+		 * - handle closing the stream
+		 * - handle generating new promises for generator to wait on
+		 */
+		void async function collect() {
+			let next: Awaited<ReturnType<(typeof opts.reader)["read"]>>;
+			loop: while (((next = await opts.reader.read()), !next.done)) {
+				const { value } = next
+				chunks.push(value)
+				if (value instanceof TsonStreamInterruptedError) {
+					if (value.cause instanceof TsonAbortError) {
+						opts.close()
+						return
+					}
+					throw value // <-- is this `throw` necessary for "stream management" / "error reporting"? Or should we only throw in the generator?
+				}
+				switch (value[0]) {
+					case ITERATOR_DONE: {
+						opts.close();
+						break loop;
+					}
+					case ITERATOR_ERROR: {
+						opts.close();
+						break;
+					}
+				}
+				resolveNext!()
+				promiseNext = new Promise<void>(resolve => resolveNext = resolve)
+			}
+			collectionDone = true
+			resolveNext!()
+		}()
+
+		/**
+		 * Generator that yields values from the stream
+		 * - handles waiting for chunks if stream is still active
+		 * - handles throwing errors from values
+		 */
+		return async function* generator() {
+			await promiseNext
+			for (let i = 0; i < chunks.length; i++) {
+				const value = chunks[i]!
+				if (value instanceof TsonStreamInterruptedError) {
+					if (value.cause instanceof TsonAbortError) {
+						return;
+					}
+					throw value;
+				}
+				switch (value[0]) {
+					case ITERATOR_DONE: {
+						return;
+					}
+
+					case ITERATOR_ERROR: {
+						throw TsonPromiseRejectionError.from(value[1]);
+					}
+
+					case ITERATOR_VALUE: {
+						yield value[1];
+						break; // <-- breaks the switch, not the loop
+					}
+				}
+				if (i === chunks.length - 1) {
+					if (collectionDone) break
+					await promiseNext
+					if (collectionDone) break
+				}
+			}
+		};
+	},
+	key: "AsyncGeneratorFunction",
+	serializeIterator: async function* serialize(opts) {
+		if (opts.value.length !== 0) {
+			throw new Error(
+				`AsyncGeneratorFunction must have 0 arguments to be serializable, got ${opts.value.length}`
+			);
+		}
+		try {
+			const iterator = opts.value()
+			for await (const value of iterator) {
+				yield [ITERATOR_VALUE, value];
+			}
+
+			yield [ITERATOR_DONE];
+		} catch (err) {
+			yield [ITERATOR_ERROR, err];
+		}
+	},
+	test: isAsyncGeneratorFunction,
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,3 +38,4 @@ export * from "./async/asyncErrors.js";
 // type handlers
 export * from "./async/handlers/tsonPromise.js";
 export * from "./async/handlers/tsonAsyncIterable.js";
+export * from "./async/handlers/tsonAsyncGeneratorFunction.js";


### PR DESCRIPTION
This PR is a proposal for `tsonAsyncGeneratorFunction`: a serializer that can serialize a generator *function* and deserialize it into a generator *function*. This would allow for iterators that can be iterated many times

Pros
- this could be useful in the context of a cached query, read in several places of an app, or at several ≠ times
- this could be useful in the context of react where a component might be re-rendered many times

Cons
- this might encourage bad practices (though I'm not sure what "bad practices" are in the age of streaming) by making it easy to "overly suspend" a component, whereas using a simple iterator would have forced the developper to store the data somewhere on first pass and never suspend again after that
- this might eat up more RAM than a simple iterator because the entire stream is exhausted and its result stored, even if the generator is never read (or only partially read). This could maybe be improved upon by using the `generator` and `collect` functions as coroutines and only read from the stream when needed... But doing so might also keep the stream open for an unreasonably long time.

Limits
- only a generator function expecting 0 arguments can be serialized (`functionName.length === 0`) because on the client side it doesn't contain any logic, only yields data

If the idea seems sound and this is something we want to add to tupleson, I will write more tests (for now, there is only 1 test for the success case, errors/interruptions aren't tested).