### PR TITLE
fix: rewrite bundled extensions to mjs for esm build

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -7,5 +7,20 @@ export default defineConfig({
 	entry: ["src/**/*.ts", "!src/**/*.test.*"],
 	format: ["cjs", "esm"],
 	outDir: "lib",
+	plugins: [
+		{
+			name: "fix-cjs",
+			renderChunk(_, chunk) {
+				if (this.format === "esm") {
+					// replace `from '...js'` with `from '...mjs'` for mjs imports & exports
+					const code = chunk.code.replace(
+						/from ['"](.*)\.js['"]/g,
+						"from '$1.mjs'",
+					);
+					return { code };
+				}
+			},
+		},
+	],
 	sourcemap: true,
 });


### PR DESCRIPTION
The current `index.mjs` re-exports from the CJS `.js` files instead of the ESM `.mjs` files: https://unpkg.com/browse/tupleson@0.23.0/lib/index.mjs. I guess tsup does not rewrite the extensions. This PR adds an esbuild plugin to rewrite the extensions for the ESM build.